### PR TITLE
Fix min/max version to align with XML v7 minimum

### DIFF
--- a/packages/unraid-plugin/unraidclaw.plg
+++ b/packages/unraid-plugin/unraidclaw.plg
@@ -11,7 +11,7 @@
 <!ENTITY md5       "449a27c1b971857b63bae367d44a5cbe">
 ]>
 
-<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.12.0" max="7.99.99" support="https://forums.unraid.net/topic/197498-plugin-support-unraidclaw-ai-agent-gateway-with-permission-control/" description="Permission-enforcing REST API gateway that lets AI agents manage your Unraid server with fine-grained access control.">
+<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="7.0.0" support="https://forums.unraid.net/topic/197498-plugin-support-unraidclaw-ai-agent-gateway-with-permission-control/" description="Permission-enforcing REST API gateway that lets AI agents manage your Unraid server with fine-grained access control.">
 
 <CHANGES>
 ### 0.1.27


### PR DESCRIPTION
The PLG min field overrides the MinVer set in the XML, and the XML states in the description the min version is 7.